### PR TITLE
Improved card header and table

### DIFF
--- a/CacheManager/resources/views/widget.blade.php
+++ b/CacheManager/resources/views/widget.blade.php
@@ -1,7 +1,8 @@
-<div id="cachemanager" class="card">
-    <div class="card-header">
-        <h2 style="display: inline; vertical-align: middle;"><em class="icon icon-database"></em> Cache Manager</h2>
-        <div class="btn-group pull-right">
+<div id="cachemanager" class="card flush">
+    <div class="head">
+        <h1>Cache Manager</h1>
+
+        <div class="btn-group">
             <button type="button" class="btn-more dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 <i class="icon icon-dots-three-vertical"></i>
             </button>
@@ -10,18 +11,23 @@
                 <li><a href="{{ $github_page }}" target="_blank"><span class="icon icon-github" aria-hidden="true"></span> Github Page</a></li>
             </ul>
         </div>
+
     </div>
 
     <div class="card-body">
-        <div>
-            <ul class="list list-separator">
-                <li>
-                    <a href="/{{ $cp_path }}/addons/cachemanager/clear-cache"><em class="icon icon-trash"></em> Clear Cache</a>
-                </li>
-                <li class="border-top">
-                    <a href="/{{ $cp_path }}/addons/cachemanager/update-stache"><em class="icon icon-cw"></em> Update Stache</a>
-                </li>
-            </ul>
-        </div>
+        <table class="control">
+            <tbody>
+                <tr>
+                    <td>
+                        <a href="/{{ $cp_path }}/addons/cachemanager/clear-cache"><em class="icon icon-trash"></em> Clear Cache</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <a href="/{{ $cp_path }}/addons/cachemanager/update-stache"><em class="icon icon-cw"></em> Update Stache</a>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
     </div>
 </div>


### PR DESCRIPTION
It appears that the `list` component is busted in the recent releases of Statamic. This may have something to do with missing modifier classes, but I think it might be best to use a table instead.

Old:
<img width="404" alt="screenshot 2016-06-11 14 05 07" src="https://cloud.githubusercontent.com/assets/414211/15987459/3852c852-2fde-11e6-9bc8-ddcb344efdc3.png">

New:
- Cache actions are now wrapped in table rows
- Removed widget title icon to save horizontal space

<img width="383" alt="screenshot 2016-06-11 14 04 41" src="https://cloud.githubusercontent.com/assets/414211/15987461/3ee29b98-2fde-11e6-9a88-5f8d77e19620.png">
