### PR TITLE
Added glide cache clearing

### DIFF
--- a/CacheManager/CacheManager.php
+++ b/CacheManager/CacheManager.php
@@ -23,4 +23,9 @@ class CacheManager
     {
         Cache::clear();
     }
+
+    public function clearGlide()
+    {
+        \Please::call('clear:glide');
+    }
 }

--- a/CacheManager/CacheManagerController.php
+++ b/CacheManager/CacheManagerController.php
@@ -80,4 +80,25 @@ class CacheManagerController extends Controller
             return back()->withErrors('error', ' Problem clearing your cache' . $e);
         }
     }
+
+
+    /**
+     * Clear Glide cache
+     */
+    public function clearGlide()
+    {
+
+        try {
+            $this->cachemanager->clearGlide();
+
+            // Log success returns
+            Log::info('Glide cache cleared successfully');
+
+            // Return back to dashboard with success message
+            return back()->with('success', 'Glide cache cleared successfully');
+        } catch (\Exception $e) {
+            Log::error('Problem clearing glide cache');
+            return back()->withErrors('error', ' Problem clearing glide cache' . $e);
+        }
+    }
 }

--- a/CacheManager/resources/views/widget.blade.php
+++ b/CacheManager/resources/views/widget.blade.php
@@ -24,6 +24,11 @@
                 </tr>
                 <tr>
                     <td>
+                        <a href="{{ route('cachemanager.clear-glide') }}"><em class="icon icon-trash"></em> Clear Glide (image) cache</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
                         <a href="{{ route('cachemanager.update-stache') }}"><em class="icon icon-cw"></em> Update Stache</a>
                     </td>
                 </tr>

--- a/CacheManager/routes.yaml
+++ b/CacheManager/routes.yaml
@@ -10,3 +10,6 @@ routes:
   /update-stache:
     uses: updateStache
     as: cachemanager.update-stache
+  /clear-glide:
+    uses: clearGlide
+    as: cachemanager.clear-glide


### PR DESCRIPTION
Had Glide configured to generate image presets on each asset upload, but when deleting an asset and uploading a new one with same name, old cached images were still showing so I decided to add this Clear glide cache button.